### PR TITLE
Test consistency between default.php and metadata.php

### DIFF
--- a/skel/_test/general.test.skel
+++ b/skel/_test/general.test.skel
@@ -36,15 +36,25 @@ class general_plugin_@@PLUGIN_NAME@@_test extends DokuWikiTest {
      * conf/metadata.php.
      */
     public function test_plugin_conf() {
-        include(__DIR__.'/../conf/default.php');
-        include(__DIR__.'/../conf/metadata.php');
-
-        foreach ($conf as $key => $value) {
-            $this->assertTrue(array_key_exists($key, $meta),'Key $meta[\'' . $key . '\'] missing in ' . DOKU_PLUGIN .'@@PLUGIN_NAME@@/conf/metadata.php');
+        $conf_file = __DIR__.'/../conf/default.php';
+        if (file_exists($conf_file)){
+            include($conf_file);
+        }
+        $meta_file = __DIR__.'/../conf/metadata.php';
+        if (file_exists($meta_file)) {
+            include($meta_file);
         }
 
-        foreach ($meta as $key => $value) {
-            $this->assertTrue(array_key_exists($key, $conf),'Key $conf[\'' . $key . '\'] missing in ' . DOKU_PLUGIN .'@@PLUGIN_NAME@@/conf/default.php');
+        $this->assertEquals(gettype($conf), gettype($meta),'Both ' . DOKU_PLUGIN . '@@PLUGIN_NAME@@/conf/default.php and ' . DOKU_PLUGIN . '@@PLUGIN_NAME@@/conf/metadata.php have to exist and contain the same keys.');
+
+        if (gettype($conf) != 'NULL' && gettype($meta) != 'NULL') {
+            foreach($conf as $key => $value) {
+                $this->assertArrayHasKey($key, $meta, 'Key $meta[\'' . $key . '\'] missing in ' . DOKU_PLUGIN . '@@PLUGIN_NAME@@/conf/metadata.php');
+            }
+
+            foreach($meta as $key => $value) {
+                $this->assertArrayHasKey($key, $conf, 'Key $conf[\'' . $key . '\'] missing in ' . DOKU_PLUGIN . '@@PLUGIN_NAME@@/conf/default.php');
+            }
         }
 
     }


### PR DESCRIPTION
Add a test to ensure that every conf['...'] entry in conf/default.php has a corresponding meta['...'] entry in metadata.php.
