### PR TITLE
feat(test): modernize example test

### DIFF
--- a/index.php
+++ b/index.php
@@ -146,13 +146,13 @@ function create_bundle($conf) {
 
     // unit tests
     if(!empty($conf['use_tests'])) {
-        $skel     = file_get_contents('./skel/_test/general.test.skel');
+        $skel     = file_get_contents('./skel/_test/GeneralTest.skel');
         $skel     = str_replace(
             array_keys($search_replace),
             array_values($search_replace), $skel
         );
         $bundle[] = array(
-            'path' => '_test/general.test.php',
+            'path' => '_test/GeneralTest.php',
             'skel' => $skel
         );
 

--- a/skel/_test/GeneralTest.skel
+++ b/skel/_test/GeneralTest.skel
@@ -1,17 +1,24 @@
 <?php
+
+declare(strict_types=1);
+
+namespace dokuwiki\plugin\@@PLUGIN_NAME@@\test;
+
+use DokuWikiTest;
+
 /**
  * General tests for the @@PLUGIN_NAME@@ plugin
  *
  * @group plugin_@@PLUGIN_NAME@@
  * @group plugins
  */
-class general_plugin_@@PLUGIN_NAME@@_test extends DokuWikiTest
+class GeneralTest extends DokuWikiTest
 {
 
     /**
      * Simple test to make sure the plugin.info.txt is in correct format
      */
-    public function test_plugininfo()
+    public function testPluginInfo(): void
     {
         $file = __DIR__ . '/../plugin.info.txt';
         $this->assertFileExists($file);
@@ -37,13 +44,18 @@ class general_plugin_@@PLUGIN_NAME@@_test extends DokuWikiTest
      * Test to ensure that every conf['...'] entry in conf/default.php has a corresponding meta['...'] entry in
      * conf/metadata.php.
      */
-    public function test_plugin_conf()
+    public function testPluginConf(): void
     {
         $conf_file = __DIR__ . '/../conf/default.php';
+        $meta_file = __DIR__ . '/../conf/metadata.php';
+
+        if (!file_exists($conf_file) && !file_exists($meta_file)) {
+            self::markTestSkipped('No config files exist -> skipping test');
+        }
+
         if (file_exists($conf_file)) {
             include($conf_file);
         }
-        $meta_file = __DIR__ . '/../conf/metadata.php';
         if (file_exists($meta_file)) {
             include($meta_file);
         }
@@ -54,7 +66,7 @@ class general_plugin_@@PLUGIN_NAME@@_test extends DokuWikiTest
             'Both ' . DOKU_PLUGIN . '@@PLUGIN_NAME@@/conf/default.php and ' . DOKU_PLUGIN . '@@PLUGIN_NAME@@/conf/metadata.php have to exist and contain the same keys.'
         );
 
-        if (gettype($conf) != 'NULL' && gettype($meta) != 'NULL') {
+        if ($conf !== null && $meta !== null) {
             foreach ($conf as $key => $value) {
                 $this->assertArrayHasKey(
                     $key,


### PR DESCRIPTION
This test now uses types, namespaces, a matching file and class name and names that follow conventions.

Also, it doesn't fail on PHP8 if there are no `$conf` files.